### PR TITLE
maven repo now uses HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <repository>
             <id>eis-public-repo</id>
             <name>maven-public</name>
-            <url>http://maven.iais.fraunhofer.de/artifactory/eis-ids-public</url>
+            <url>https://maven.iais.fraunhofer.de/artifactory/eis-ids-public</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Was getting a host unreachable error in the maven build.. was solved with adding an https to the maven repository in the pom